### PR TITLE
Added MANIFEST.in to include examples, docs and tests.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include COPYING example.py
+recursive-include docs *
+recursive-include examples *.py *.pbs
+recursive-include platypus/tests *.py
+prune dist


### PR DESCRIPTION
I came across a problem writing the conda build recipe where the tests and licence file are not included in the source distribution (tar.gz) that is uploaded to pypi. These are not found by setuptools by default. Therefore I've added a `MANIFEST.in` file to add these files when `sdist` is used. 