### PR TITLE
Added conda installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ To install the latest development version of Platypus, run the following command
     python setup.py install
 ```
 
+#### Anaconda
+
+Platypus is also available via conda-forge. 
+
+```
+    conda config --add channels conda-forge
+    conda install platypus-opt
+```
+
+For more information see the [feedstock](https://github.com/conda-forge/platypus-opt-feedstock) located here. 
+
 ### License
 
 Platypus is released under the GNU General Public License.


### PR DESCRIPTION
`platypus-opt` has now been accepted to conda-forge. See the feedstock below. 

https://github.com/conda-forge/platypus-opt-feedstock

This PR adds installation instructions for anaconda and links to the feedstock.
