### PR TITLE
Fix dict_keys indexing in Python3 as referred in issue #72

### DIFF
--- a/platypus/algorithms.py
+++ b/platypus/algorithms.py
@@ -1418,7 +1418,7 @@ class RegionBasedSelector(Selector):
         
     def draw(self):
         index = random.randrange(len(self.grid.keys()))
-        key = self.grid.keys()[index]
+        key = list(self.grid.keys())[index]
         return (key, self.grid[key])
         
     def select_one(self, population):


### PR DESCRIPTION
**Problem**: Attempt to index a dict_key data type (which does not support the **indexing** operation) in Python 3.
**Occured when**: using the algorithm **PESA2**. Since it requires the RegionBasedSelector to draw a random key from the grid, it will fail uppon the second iteration of PESA2.
**Possible causes**: In Python 2, accessing the keys of a dictionary would retrieve a list, instead of a dict_type. The list data type supports the indexing operation. The problem exists in Python 3.

**Proposed Solution**: wrap the result of dict.keys() call in a list. 
The proposed solution is compatible both for Python 2 and Python 3, which might be important for compatibility issues. 


I have tested the proposed solution and it all worked fine. 
If accepted, this pull request closes #72.