### PR TITLE
Update mpipool.py

### DIFF
--- a/platypus/mpipool.py
+++ b/platypus/mpipool.py
@@ -118,12 +118,12 @@ class MPIPool(object):
                 result = self.function(task)
             except:
                 tb = traceback.format_exc()
-                self.comm.isend(MPIPoolException(tb), dest=0, tag=status.tag)
+                self.comm.send(MPIPoolException(tb), dest=0, tag=status.tag)
                 return
             if self.debug:
                 print("Worker {0} sending answer {1} with tag {2}."
                       .format(self.rank, result, status.tag))
-            self.comm.isend(result, dest=0, tag=status.tag)
+            self.comm.send(result, dest=0, tag=status.tag)
 
     def map(self, function, tasks, callback=None):
         """


### PR DESCRIPTION
Fixes #94.  Changed isend() to send() in the wait() method.  isend() is only used when a response is expected.  Worker nodes don't get a response to their message.  See https://groups.google.com/forum/#!msg/mpi4py/ayRwvSslflc/Lt7CjyaUAAAJ for discussion on this.