### PR TITLE
Fixed bug on EpsilonIndicator

### DIFF
--- a/platypus/indicators.py
+++ b/platypus/indicators.py
@@ -84,7 +84,7 @@ class EpsilonIndicator(Indicator):
             return POSITIVE_INFINITY
         
         normalize(feasible, self.minimum, self.maximum)
-        return max([min([max([s2.normalized_objectives[k] - s1.normalized_objectives[k] for k in range(s2.problem.nobjs)]) for s2 in set]) for s1 in self.reference_set])
+        return max([min([max([s2.normalized_objectives[k] - s1.normalized_objectives[k] for k in range(s2.problem.nobjs)]) for s2 in feasible]) for s1 in self.reference_set])
     
 class Spacing(Indicator):
     


### PR DESCRIPTION
Fixed a bug on EpsilonIndicator where all points were used instead of only the feasible ones, this caused an error to be raised when s2 tried to get it's normalized_objectives attribute which wasn't calculated because the normalization was done on the feasible set.