### PR TITLE
algorithms.py: Adres SyntaxWarning by replacing `is` by `==` in if-statement

### DIFF
--- a/platypus/algorithms.py
+++ b/platypus/algorithms.py
@@ -1062,7 +1062,7 @@ class CMAES(Algorithm):
         else:
             self.archive = Archive(EpsilonDominance(epsilons))
             
-        if indicator is "hypervolume":
+        if indicator == "hypervolume":
             self.fitness_evaluator = HypervolumeFitnessEvaluator()
             self.fitness_comparator = AttributeDominance(False)
         else:


### PR DESCRIPTION
Adres SyntaxWarning in algorithms.py by replacing `is` by `==` in if-statement.