### PR TITLE
CI: Create workflow that builds and deploys to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Build distribution
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install build dependencies
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade build wheel setuptools
+      - name: Build distributions
+        shell: bash -l {0}
+        run: python -m build
+      - name: Publish package
+        if: github.repository == 'Project-Platypus/Platypus' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Add a CI workflow that automatically builds Platypus-Opt and deploys a wheel to PyPI. If runs on each push and pull request to test wheel building, but only deploys to PyPI when a tag is created.

To deploy to PyPI is uses the [PyPI publish GitHub Action](https://github.com/pypa/gh-action-pypi-publish). It uses the [API token](https://pypi.org/help/#apitoken) feature of PyPI, which is recommended to restrict the access the action has.

The secret used in `${{ secrets.PYPI_API_TOKEN }}` needs to be created on the settings page. See [Creating & using secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets).