### PR TITLE
Remove six package

### DIFF
--- a/platypus/config.py
+++ b/platypus/config.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Platypus.  If not, see <http://www.gnu.org/licenses/>.
 
-import six
 from .types import Real, Binary, Permutation, Subset
 from .operators import GAOperator, CompoundOperator, CompoundMutation, SBX, PM, HUX, BitFlip, PMX, Insertion, Swap, SSX, Replace
 from .core import PlatypusError

--- a/platypus/experimenter.py
+++ b/platypus/experimenter.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Platypus.  If not, see <http://www.gnu.org/licenses/>.
 
-import six
 import time
 import datetime
 import functools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
-six
 pytest
 mock

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(name='Platypus-Opt',
       license="GNU GPL version 3",
       url='https://github.com/Project-Platypus/Platypus',
       packages=['platypus'],
-      install_requires=['six'],
       tests_require=['pytest', 'mock'],
       python_requires='>=3.6'
      )


### PR DESCRIPTION
Following up on https://github.com/Project-Platypus/Platypus/pull/194, remove the `six` package as it's no longer referenced and needed after upgrading to Python 3.