### PR TITLE
Require Python 3.8+ 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.x", "pypy-3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: Tests
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
   schedule: # Run tests once a week to detect regressions
     - cron: '0 0 * * 1'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.x", "pypy-3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.x", "pypy-3.10"]
 
     steps:
     - uses: actions/checkout@v4
@@ -21,6 +21,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: "pip"
+        allow-prereleases: true
 
     - name: Run tests - Python ${{ matrix.python-version }}
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 dist/
 private/
 .ipynb_checkpoints/
+.idea

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: v3.1.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py38-plus]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/platypus/core.py
+++ b/platypus/core.py
@@ -80,7 +80,7 @@ class FixedLengthArray:
 
     def __str__(self):
         return "[" + ", ".join(list(map(str, self._data))) + "]"
-        
+
     def __repr__(self):
         return self.__str__()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 readme = "README.md"
 license = { file="COPYING" }
-requires-python = ">= 3.6"
+requires-python = ">= 3.8"
 dependencies = ["numpy"]
 dynamic = ["version"]  # Version is read from platypus/__init__.py
 


### PR DESCRIPTION
Drop Python 3.6 and 3.7, since both are end-of-life. Require Python 3.8+.

Also adds testing for Python 3.12 and Python 3.13, and does a few small cleanups.