### PR TITLE
Add .readthedocs.yaml configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-lts-latest
+  tools:
+    python: latest
+
+sphinx:
+  configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,3 +10,8 @@ build:
 
 sphinx:
   configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,5 +13,4 @@ sphinx:
 
 python:
   install:
-    - method: pip
-      path: .
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
Add a simple .readthedocs.yaml configuration file.

See https://docs.readthedocs.io/en/stable/config-file/v2.html

Closes #226.