### PR TITLE
CI: Let pytest treat warnings as errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Run tests - Python ${{ matrix.python-version }}
       run: |
         pip install .[test]
-        python -m pytest
+        python -m pytest -rA -Werror


### PR DESCRIPTION
When running the tests, let pytest treat warnings as errors.

Also print a summary of tests using the `-rA` flag.