### PR TITLE
Include examples in CI

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -15,17 +15,16 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      - name: Get Python version
+        run: |
+          PYTHON_VERSION=$(cat pyproject.toml | grep "requires-python" | grep -Eo "[0-9]+\.[0-9]+")
+          echo "PYTHON_VERSION=${PYTHON_VERSION}" >> $GITHUB_ENV
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
-          allow-prereleases: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,46 @@
+name: Test Examples
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule: # Run tests once a week to detect regressions
+    - cron: '0 0 * * 1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          allow-prereleases: true
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -y install mpi mpich libmpich-dev libopenmpi-dev
+          pip install .[full]
+
+      - name: Run examples
+        run: |
+          find examples/ -name '*.py' -not -name '*mpi*' | \
+            xargs -I {} sh -c "echo '{}': && python '{}' && echo ''"
+
+      - name: Run MPI examples
+        run: |
+          lamboot
+          find examples/ -name '*.py' -name '*mpi*' | \
+            xargs -I {} sh -c "echo '{}': && mpirun -np 2 --oversubscribe python '{}' && echo ''"
+          lamhalt

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Run examples
         run: |
           find examples/ -name '*.py' -not -name '*mpi*' | \
-            xargs -I {} sh -c "echo '{}': && python '{}' && echo ''"
+            xargs -I {} sh -c "echo '{}:' && python '{}' && echo ''"
 
       - name: Run MPI examples
         run: |
           lamboot
           find examples/ -name '*.py' -name '*mpi*' | \
-            xargs -I {} sh -c "echo '{}': && mpirun -np 2 --oversubscribe python '{}' && echo ''"
+            xargs -I {} sh -c "echo '{}:' && mpirun -np 2 --oversubscribe python '{}' && echo ''"
           lamhalt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,17 +7,27 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-      - name: Set up Python 3.12
+
+      - name: Get Python version
+        run: |
+          PYTHON_VERSION=$(cat pyproject.toml | grep "requires-python" | grep -Eo "[0-9]+\.[0-9]+")
+          echo "PYTHON_VERSION=${PYTHON_VERSION}" >> $GITHUB_ENV
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+
       - name: Install build dependencies
         run: |
           pip install --upgrade pip
           pip install --upgrade build wheel setuptools
+
       - name: Build distributions
         shell: bash -l {0}
         run: python -m build
+
       - name: Publish package
         if: github.repository == 'Project-Platypus/Platypus' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,40 +16,41 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
 
     steps:
-    - uses: actions/checkout@v4
+      - name: Checkout source
+        uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: "pip"
-        allow-prereleases: true
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          allow-prereleases: true
 
-    - name: Install dependencies
-      run: |
-        pip install .[test]
+      - name: Install dependencies
+        run: |
+          pip install .[test]
 
-    - name: Run flake8
-      run: |
-        # Ignore existing issues, but we should eventually fix these...
-        #    E127 - Continuation line over-indented for visual indent
-        #    E128 - Continuation line under-indented for visual indent
-        #    E129 - Visually indented line with same indent as next logical line
-        #    E201 - Whitespace after '('
-        #    E202 - Whitespace before ')'
-        #    E203 - Whitespace before ':'
-        #    E225 - Missing whitespace around operator
-        #    E251 - Unexpected spaces around keyword / parameter equals
-        #    E302 - Expected 2 blank lines, found N
-        #    E501 - Line too long (N > 79 characters)
-        #    E741 - Do not use variables named 'I', 'O', or 'l'
-        #    F401 - Module imported but unused
-        #    F403 - 'from module import *' used; unable to detect undefined names
-        #    F405 - Name may be undefined, or defined from star imports: module
-        flake8 --extend-ignore=E127,E128,E129,E201,E202,E203,E225,E251,E302,E501,E741 \
-            --per-file-ignores="__init__.py:F401,F403 examples/*:E305,F403,F405 */tests/*:F403,F405" \
-            platypus/ examples/ example.py
+      - name: Run flake8
+        run: |
+          # Ignore existing issues, but we should eventually fix these...
+          #    E127 - Continuation line over-indented for visual indent
+          #    E128 - Continuation line under-indented for visual indent
+          #    E129 - Visually indented line with same indent as next logical line
+          #    E201 - Whitespace after '('
+          #    E202 - Whitespace before ')'
+          #    E203 - Whitespace before ':'
+          #    E225 - Missing whitespace around operator
+          #    E251 - Unexpected spaces around keyword / parameter equals
+          #    E302 - Expected 2 blank lines, found N
+          #    E501 - Line too long (N > 79 characters)
+          #    E741 - Do not use variables named 'I', 'O', or 'l'
+          #    F401 - Module imported but unused
+          #    F403 - 'from module import *' used; unable to detect undefined names
+          #    F405 - Name may be undefined, or defined from star imports: module
+          flake8 --extend-ignore=E127,E128,E129,E201,E202,E203,E225,E251,E302,E501,E741 \
+              --per-file-ignores="__init__.py:F401,F403 examples/*:E305,F403,F405 */tests/*:F403,F405" \
+              platypus/ examples/ example.py
 
-    - name: Run tests
-      run: |
-        python -m pytest -rA -Werror
+      - name: Run tests
+        run: |
+          python -m pytest -rA -Werror

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,5 @@ Platypus.egg-info/
 Platypus_Opt.egg-info/
 build/
 dist/
-private/
 .ipynb_checkpoints/
 .idea

--- a/examples/simple_mpi.py
+++ b/examples/simple_mpi.py
@@ -15,7 +15,7 @@ class DTLZ2_Slow(DTLZ2):
 if __name__ == "__main__":
     # define the problem definition
     problem = DTLZ2_Slow()
-    
+
     with MPIPool() as pool:
         # only run the algorithm on the master process
         if not pool.is_master():

--- a/examples/simple_parallel.py
+++ b/examples/simple_parallel.py
@@ -4,7 +4,7 @@ from platypus import NSGAII, DTLZ2, ProcessPoolEvaluator
 class DTLZ2_Slow(DTLZ2):
 
     def evaluate(self, solution):
-        sum(range(1000000))
+        sum(range(100000))
         super().evaluate(solution)
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ dynamic = ["version"]  # Version is read from platypus/__init__.py
 "Bug Tracker" = "https://github.com/Project-Platypus/Platypus/issues"
 
 [project.optional-dependencies]
-optional = ["numpy"]
-test = ["pytest", "mock", "flake8", "Platypus-Opt[optional]"]
+test = ["pytest", "mock", "flake8", "numpy"]
 doc = ["sphinx"]
+full = ["mpi4py", "Platypus-Opt[test]", "Platypus-Opt[doc]"]
 
 [tool.setuptools.dynamic]
 version = {attr = "platypus.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 readme = "README.md"
 license = { file="COPYING" }
 requires-python = ">= 3.8"
-dependencies = ["matplotlib"]
+dependencies = []
 dynamic = ["version"]  # Version is read from platypus/__init__.py
 
 [project.urls]
@@ -22,7 +22,7 @@ dynamic = ["version"]  # Version is read from platypus/__init__.py
 [project.optional-dependencies]
 test = ["pytest", "mock", "flake8", "numpy"]
 doc = ["sphinx"]
-full = ["mpi4py", "Platypus-Opt[test]", "Platypus-Opt[doc]"]
+full = ["mpi4py", "matplotlib", "Platypus-Opt[test]", "Platypus-Opt[doc]"]
 
 [tool.setuptools.dynamic]
 version = {attr = "platypus.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 readme = "README.md"
 license = { file="COPYING" }
 requires-python = ">= 3.8"
-dependencies = []
+dependencies = ["matplotlib"]
 dynamic = ["version"]  # Version is read from platypus/__init__.py
 
 [project.urls]


### PR DESCRIPTION
Adds the `examples.yml` workflow to test the Python examples.  Note that this does not test each example for correctness, as that's the job of `tests.yml`, this just ensures the examples run without error.  As part of this change, `matplotlib` is added as an optional dependency as it's used in some of the examples to generate plots.  Install using:

```bash
pip install .[full]
```

