### PR TITLE
Remove star imports in __init__

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
           #    F403 - 'from module import *' used; unable to detect undefined names
           #    F405 - Name may be undefined, or defined from star imports: module
           flake8 --extend-ignore=E127,E128,E129,E201,E202,E203,E225,E251,E302,E501,E741 \
-              --per-file-ignores="__init__.py:F401,F403 examples/*:E305,F403,F405 */tests/*:F403,F405" \
+              --per-file-ignores="__init__.py:F401 examples/*:E305,F403,F405 */tests/*:F403,F405" \
               platypus/ examples/ example.py
 
       - name: Run tests

--- a/examples/plot_operators.py
+++ b/examples/plot_operators.py
@@ -1,6 +1,7 @@
 # Generates a plot showing the distributions of six real-valued operators.
 import matplotlib.pyplot as plt
 from platypus import *
+from platypus.tools import add, subtract
 
 problem = Problem(2, 0)
 problem.types[:] = Real(-1, 1)

--- a/platypus/__init__.py
+++ b/platypus/__init__.py
@@ -17,15 +17,47 @@
 # You should have received a copy of the GNU General Public License
 # along with Platypus.  If not, see <http://www.gnu.org/licenses/>.
 
-from .core import *
-from .algorithms import *
-from .evaluator import *
-from .experimenter import *
-from .indicators import *
-from .operators import *
-from .problems import *
-from .tools import *
-from .types import *
-from .weights import *
+from .core import PlatypusError, FixedLengthArray, Problem, Generator, \
+    Variator, Mutation, Selector, TerminationCondition, MaxEvaluations, \
+    MaxTime, Algorithm, Constraint, Solution, Dominance, ParetoDominance, \
+    EpsilonDominance, AttributeDominance, Archive, AdaptiveGridArchive, \
+    FitnessArchive, EpsilonBoxArchive, unique, nondominated, \
+    nondominated_cmp, nondominated_sort, crowding_distance, \
+    nondominated_split, nondominated_prune, nondominated_truncate, \
+    truncate_fitness, normalize, FitnessEvaluator, \
+    HypervolumeFitnessEvaluator, Indicator
+
+from .config import PlatypusConfig, default_variator, default_mutator
+
+from .algorithms import AbstractGeneticAlgorithm, SingleObjectiveAlgorithm, \
+    GeneticAlgorithm, EvolutionaryStrategy, NSGAII, EpsMOEA, GDE3, SPEA2, \
+    MOEAD, NSGAIII, ParticleSwarm, OMOPSO, SMPSO, CMAES, IBEA, PAES, \
+    RegionBasedSelector, PESA2, PeriodicAction, AdaptiveTimeContinuation, \
+    EpsilonProgressContinuation, EpsNSGAII
+
+from .evaluator import Job, Evaluator, MapEvaluator, SubmitEvaluator, \
+    ApplyEvaluator, PoolEvaluator, MultiprocessingEvaluator, \
+    ProcessPoolEvaluator
+
+from .experimenter import ExperimentJob, IndicatorJob, experiment, calculate, \
+    display
+
+from .indicators import GenerationalDistance, InvertedGenerationalDistance, \
+    EpsilonIndicator, Spacing, Hypervolume
+
+from .operators import RandomGenerator, InjectedPopulation, \
+    TournamentSelector, PM, SBX, GAOperator, CompoundMutation, \
+    CompoundOperator, DifferentialEvolution, UniformMutation, \
+    NonUniformMutation, UM, PCX, UNDX, SPX, BitFlip, HUX, Swap, PMX, \
+    Insertion, Replace, SSX, Multimethod
+
+from .problems import DTLZ1, DTLZ2, DTLZ3, DTLZ4, DTLZ7, WFG, WFG1, WFG2, \
+    WFG3, WFG4, WFG5, WFG6, WFG7, WFG8, WFG9, UF1, UF2, UF3, UF4, UF5, UF6, \
+    UF7, UF8, UF9, UF10, UF11, UF12, UF13, CF1, CF2, CF3, CF4, CF5, CF6, CF7, \
+    CF8, CF9, CF10, ZDT, ZDT1, ZDT2, ZDT3, ZDT4, ZDT5, ZDT6
+
+from .types import Type, Real, Binary, Integer, Permutation, Subset
+
+from .weights import chebyshev, pbi, random_weights, normal_boundary_weights
 
 __version__ = "1.2.0"

--- a/platypus/problems.py
+++ b/platypus/problems.py
@@ -142,7 +142,6 @@ class DTLZ4(Problem):
         solution.evaluate()
         return solution
 
-
 class DTLZ7(Problem):
 
     def __init__(self, nobjs = 2):


### PR DESCRIPTION
Remove the * imports in __init__ that are exporting all defined classes, functions, and variables, and instead only export what should be part of the API.

This is primarily to fix naming conflicts, but also good practice in general.