### PR TITLE
Add top navigation buttons in docs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ Platypus_Opt.egg-info/
 build/
 dist/
 docs/_build/
+docs/make.bat
 .ipynb_checkpoints/
 .idea

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,10 @@ add_module_names = False
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
 
+html_theme_options = {
+    'prev_next_buttons_location': 'both'
+}
+
 # The initial api/ contents were created with:
 #   sphinx-apidoc --separate --remove-old --no-toc -o docs/api platypus "*test*"
 #


### PR DESCRIPTION
This pull request updates `conf.py` to display `Previous` and `Next` navigation buttons at both the top and bottom of documentation pages, improving navigation on long pages. It also adds `make.bat` to `.gitignore` since the file is generated locally by Sphinx on Windows and is not present in the main repository.
