### PR TITLE
Fix CF8/CF9/CF10 evaluate writing only 2 of 3 objectives

### DIFF
--- a/platypus/problems.py
+++ b/platypus/problems.py
@@ -1374,7 +1374,7 @@ class CF8(Problem):
         f2 = math.cos(0.5*math.pi*x[0]) * math.sin(0.5*math.pi*x[1]) + 2.0*sum2/count2
         f3 = math.sin(0.5*math.pi*x[0]) + 2.0*sum3/count3
         c1 = (f1**2 + f2**2) / (1.0 - f3**2) - a*abs(math.sin(N*math.pi*((f1**2 - f2**2) / (1.0 - f3**2) + 1.0))) - 1.0
-        solution.objectives[:] = [f1, f2]
+        solution.objectives[:] = [f1, f2, f3]
         solution.constraints[:] = [c1]
 
 class CF9(Problem):
@@ -1413,7 +1413,7 @@ class CF9(Problem):
         f2 = math.cos(0.5*math.pi*x[0]) * math.sin(0.5*math.pi*x[1]) + 2.0*sum2/count2
         f3 = math.sin(0.5*math.pi*x[0]) + 2.0*sum3/count3
         c1 = (f1**2 + f2**2) / (1.0 - f3**2) - a*math.sin(N*math.pi*((f1**2 - f2**2) / (1.0 - f3**2) + 1.0)) - 1.0
-        solution.objectives[:] = [f1, f2]
+        solution.objectives[:] = [f1, f2, f3]
         solution.constraints[:] = [c1]
 
 class CF10(Problem):
@@ -1453,7 +1453,7 @@ class CF10(Problem):
         f2 = math.cos(0.5*math.pi*x[0]) * math.sin(0.5*math.pi*x[1]) + 2.0*sum2/count2
         f3 = math.sin(0.5*math.pi*x[0]) + 2.0*sum3/count3
         c1 = (f1**2 + f2**2) / (1.0 - f3**2) - a*math.sin(N*math.pi*((f1**2 - f2**2) / (1.0 - f3**2) + 1.0)) - 1.0
-        solution.objectives[:] = [f1, f2]
+        solution.objectives[:] = [f1, f2, f3]
         solution.constraints[:] = [c1]
 
 ################################################################################


### PR DESCRIPTION
## Summary

`CF8`, `CF9`, and `CF10` declare `nobjs=3` in `__init__` but their `evaluate` methods compute `f3` and then assign only `[f1, f2]` to `solution.objectives`. Because `FixedLengthArray.__setitem__` falls through to the scalar-broadcast branch when the assigned list length doesn't match the slice length, all three objective slots end up holding the same `[f1, f2]` Python list. That makes `tuple(solution.objectives)` unhashable, which breaks `filters.unique` inside `crowding_distance` and raises `TypeError: unhashable type: 'list'` on any run touching these problems.

The fix is a one-line change in each of the three classes — `f3` is already computed, it just wasn't being written.

## Repro

```python
from platypus import CF10, NSGAII
NSGAII(CF10(), population_size=20).run(200)
# TypeError: unhashable type: 'list'
#   crowding_distance(archive) -> unique(solutions) -> _unique -> `if kval not in seen`
```

## Test plan

- [x] `NSGAII(CF10(), population_size=20).run(200)` completes cleanly (verified locally)
- [ ] Same smoke test for CF8 and CF9
- [ ] Existing test suite still passes